### PR TITLE
Updating exernal tool dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ My use case is to trigger some home automation routines based on my smartphone a
 * `curl` command
 * `jq` command
 * `websocat` command
+* `openssl` command
 * optional: `mosquitto_pub` command
 
 ## Dependencies


### PR DESCRIPTION
Dear Matsuo3rd
Specifying 'openssl' as a require command to calculate the sha1 digest of CHALLENGE and APP_TOKEN to create the SESSION_TOKEN  Without `openssl` you may never login the API (or you may be required to use other bash not builtin tool like `gnutls`) Kind regards
nbanba